### PR TITLE
correction of classpaht to allow running Sonargraph Build on Windows

### DIFF
--- a/src/main/java/com/hello2morrow/sonargraph/integration/jenkins/controller/SonargraphReportBuilder.java
+++ b/src/main/java/com/hello2morrow/sonargraph/integration/jenkins/controller/SonargraphReportBuilder.java
@@ -344,7 +344,7 @@ public final class SonargraphReportBuilder extends AbstractSonargraphRecorder im
             return false;
         }
 
-        final String sonargraphBuildCommand = javaExe.getAbsolutePath() + " -ea -cp " + clientJar.getAbsolutePath() + ":" + osgiJar.getAbsolutePath()
+        final String sonargraphBuildCommand = javaExe.getAbsolutePath() + " -ea -cp " + clientJar.getAbsolutePath() + File.pathSeparator + osgiJar.getAbsolutePath()
                 + " " + SONARGRAPH_BUILD_MAIN_CLASS + " " + configurationFile.getAbsolutePath();
 
         ProcStarter procStarter = launcher.new ProcStarter();


### PR DESCRIPTION
Classpath generated in SonargraphReportBuilder does not work on Windows. Path separator ":" needs to be replaced with systemwide path separator.