### PR TITLE
Set build result failed instead of aborted if report missing

### DIFF
--- a/src/main/java/com/hello2morrow/sonargraph/integration/jenkins/controller/AbstractSonargraphRecorder.java
+++ b/src/main/java/com/hello2morrow/sonargraph/integration/jenkins/controller/AbstractSonargraphRecorder.java
@@ -94,7 +94,7 @@ public abstract class AbstractSonargraphRecorder extends Recorder
         {
             SonargraphLogger.logToConsoleOutput(logger, Level.SEVERE, "Sonargraph analysis cannot be executed as Sonargraph report does not exist.",
                     null);
-            build.setResult(Result.ABORTED);
+            build.setResult(Result.FAILURE);
             return false;
         }
 


### PR DESCRIPTION
The 'Aborted' status means the build was manually aborted by a user.
If the plugin cannot find the input report it now sets the status to 'Failed'
instead.

Setting the status to 'Aborted' leads to some unexpected behavior for us. First of all, it is not easily recognizable that something went wrong in the build. This even goes as far as hiding other build problems: If the build fails for some reason and no Sonargraph report was generated, the publisher will change the build status from 'Failed' to 'Aborted'.

Please accept this PR to fix the behavior.